### PR TITLE
Set default panel height to full viewport height

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -18,7 +18,7 @@
     theme: 'auto',
     shortcuts: true,
     panelWidth: 380,
-    panelHeight: 520,
+    panelHeight: window.innerHeight,
     fontSize: 'medium',
     panelMode: false
   };


### PR DESCRIPTION
This PR implements the requested feature from issue #6 to make the panel use full height by default when opened.

**Changes Made:**
- Updated default `panelHeight` from `520` to `window.innerHeight` in content.js:21
- This makes the panel use full viewport height by default for both floating and panel modes

**Implementation Details:**
The change modifies the default settings object to use `window.innerHeight` instead of the hardcoded 520px value. This ensures that:
1. **Floating mode**: Panel will now open with full viewport height instead of 520px
2. **Panel mode**: Already uses `height: 100vh` via CSS, so behavior remains consistent
3. **Existing users**: Will still retain their manually resized preferences via Chrome storage
4. **New users**: Will get the full height experience by default

The implementation is clean and minimal, changing only the default value while preserving all existing resize functionality and user preferences.

Fixes #6

Generated with [Claude Code](https://claude.ai/code)