### PR TITLE
feat: reorder theme options alphabetically

### DIFF
--- a/extension/options.html
+++ b/extension/options.html
@@ -467,8 +467,8 @@
           <label for="theme">Theme</label>
           <select id="theme">
             <option value="auto">Auto (Follow System)</option>
-            <option value="light">Light</option>
             <option value="dark">Dark</option>
+            <option value="light">Light</option>
           </select>
         </div>
         

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -289,8 +289,8 @@
       <span class="toggle-label">Theme</span>
       <select id="themeSelect">
         <option value="auto">Auto</option>
-        <option value="light">Light</option>
         <option value="dark">Dark</option>
+        <option value="light">Light</option>
       </select>
     </div>
   </div>


### PR DESCRIPTION
Reordered theme options from Auto, Light, Dark to Auto, Dark, Light in both popup and options pages for better alphabetical ordering.

Fixes #22

Generated with [Claude Code](https://claude.ai/code)